### PR TITLE
タイトルを『入門 Crystal』に修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,10 @@ ASCIIDOCTOR_HTML_FLAGS = \
   -r asciidoctor-rouge \
   $(ASCIIDOCTOR_ROUGE_FLAGS)
 
-BUILD_PDFS = \
-  $(PREFIX)/techbookfest4-print.pdf \
-  $(PREFIX)/techbookfest4-web.pdf
-BUILD_HTML = $(PREFIX)/techbookfest4.html
-BUILD_FILES = $(BUILD_PDFS) $(BUILD_HTML)
+PRINT_PDF = $(PREFIX)/introducing-crystal-print.pdf
+WEB_PDF = $(PREFIX)/introducing-crystal-web.pdf
+PDFS = $(PRINT_PDF) $(WEB_PDF)
+HTML = $(PREFIX)/introducing-crystal.html
 
 ADOCS = \
   index.adoc \
@@ -38,21 +37,21 @@ ASSETS = $(shell find [0-9][0-9]-* -not -name '*.adoc')
 CRS = $(EXAMPLES) $(PROJECT_CRS)
 
 .PHONY: all
-all: $(BUILD_FILES)
+all: pdf html
 
 .PHONY: pdf print-pdf web-pdf html
 pdf: print-pdf web-pdf
-print-pdf: $(PREFIX)/techbookfest4-print.pdf
-web-pdf: $(PREFIX)/techbookfest4-web.pdf
-html: $(PREFIX)/techbookfest4.html
+print-pdf: $(PRINT_PDF)
+web-pdf: $(WEB_PDF)
+html: $(HTML)
 
-$(PREFIX)/techbookfest4-print.pdf: $(ADOCS) $(ASSETS)
+$(PRINT_PDF): $(ADOCS) $(ASSETS)
 	bundle exec asciidoctor-pdf $(ASCIIDOCTOR_PRINT_PDF_FLAGS) -o $@ $<
 
-$(PREFIX)/techbookfest4-web.pdf: $(ADOCS) $(ASSETS)
+$(WEB_PDF): $(ADOCS) $(ASSETS)
 	bundle exec asciidoctor-pdf $(ASCIIDOCTOR_WEB_PDF_FLAGS) -o $@ $<
 
-$(PREFIX)/techbookfest4.html: $(ADOCS) $(ASSETS)
+$(HTML): $(ADOCS) $(ASSETS)
 	bundle exec asciidoctor $(ASCIIDOCTOR_HTML_FLAGS) -o $@ $<
 
 .PHONY: lint lint-full redpen rubocop crystal-format format backspace

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ make
 
 ```console
 $ ls build
-techbookfest4-print.pdf techbookfest4-web.pdf techbookfest4.html
+introducing-crystal-print.pdf introducing-crystal-web.pdf introducing-crystal.html
 ```
 
 それぞれ印刷用の PDF、Web 公開用の PDF、HTML です。

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # introducing-crystal
 
-『入門Crystal』の原稿を管理するリポジトリです。
+『入門 Crystal』の原稿を管理するリポジトリです。
 
 ## 必要なもの
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# techbookfest4
+# introducing-crystal
 
-技術書典4で頒布する本を管理するリポジトリです。
+『入門Crystal』の原稿を管理するリポジトリです。
 
 ## 必要なもの
 

--- a/index.adoc
+++ b/index.adoc
@@ -1,4 +1,4 @@
-= The Crystal Programming Language
+= 入門Crystal
 crystal-jp (5t111111; arcage; at-grandpa; MakeNowJust; msky026)
 :lang: ja
 :doctype: book


### PR DESCRIPTION
@crystal-jp/introducing-crystal 

Related issue: #28 

本のタイトルを内容から『入門Crystal』ということにして、リポジトリ名も`introducing-crystal`に修正してしまいました。事後報告で申し訳ない。

タイトルに他に候補があったら意見をください。無ければマージします。