### PR TITLE
日本語中のバックスペース文字を削除

### DIFF
--- a/02-getting-started/content.adoc
+++ b/02-getting-started/content.adoc
@@ -96,7 +96,7 @@ $ sudo yum update crystal
 
 ==== Arch Linux
 
-Arch Linux では、ユーザリポジトリから Crystal をインストールできます。パッケージの依存関係を管理するための `shards` も必要になるので同様にインストールしてください。
+Arch Linux では、ユーザリポジトリから Crystal をインストールできます。パッケージの依存関係を管理するための `shards` も必要になるので同様にインストールしてください。
 
 [source,console]
 ----

--- a/04-macro/content.adoc
+++ b/04-macro/content.adoc
@@ -8,7 +8,7 @@ Crystal の Macro とは次のようなものです。
 
 * 「 Crystal のコードを書く」コード
 * コンパイルフェーズで実行され、 Crystal のコードに展開される
-* 全マクロが展開されたあとの Crystal コードが実際にコンパイルされる
+* 全マクロが展開されたあとの Crystal コードが実際にコンパイルされる
 
 これだけではイメージが湧きづらいので、Macro がどのようなものかを実際に見てみましょう。
 次のコードを見てください。
@@ -20,11 +20,11 @@ include::./examples/example_01.cr[tags=code;main]
 
 . `macro` ディレクティブを用いて Macro を定義します
 . 定義した Macro を呼び出します
-.. 引数 `my_method` `"hoge"` が Macro に渡されます
+.. 引数 `my_method` `"hoge"` が Macro に渡されます
 .. 引数をもとに処理が行われ、呼び出し箇所に Crystal コードが展開されます
 . Crystal コードに展開された後、通常のコンパイルが行われます
 
-つまり、上記の Macro 展開後は次のようになります。
+つまり、上記の Macro 展開後は次のようになります。
 
 [source,crystal]
 ----
@@ -36,7 +36,7 @@ include::./examples/example_01_expanded.cr[tags=code;main]
 
 Macro のイメージが湧きましたでしょうか。
 
-=== Macro の利点
+=== Macro の利点
 
 Macro を利用することで、コードの重複を排除できます。次のコードを見てください。
 
@@ -72,7 +72,7 @@ include::./examples/duplication_01_getter.cr[tags=code;main]
 === Macro の可読性
 
 重複の除去によって、 Macro 呼び出しのコードはすっきりしました。
-しかし、 Macro 定義のコードはどうしても複雑になってしまいます。
+しかし、 Macro 定義のコードはどうしても複雑になってしまいます。
 Macro の理解に加え、展開後の Crystal コードも理解しければならないからです。
 
 Crystal のバージョン `0.20.4` 以前は、 Macro 展開後のコードを知るすべはありませんでした。
@@ -103,7 +103,7 @@ Options:
     --stdin-filename                 Source file name to be read from STDIN
 ----
 
-`--cursor` オプションでカーソル位置を指定すると、カーソル上の Macro の展開結果を表示することができます。
+`--cursor` オプションでカーソル位置を指定すると、カーソル上の Macro の展開結果を表示することができます。
 先程の `getter` で試してみましょう。
 
 [source,console]
@@ -142,8 +142,8 @@ Crystal には、標準で搭載されている Macro があります。
 
 オブジェクトの同値性比較を行う `==` メソッドを定義します。
 
-同値性比較を行う場合、複数あるインスタンス変数の比較を行います。
-通常の場合、コードは次のようになります。
+同値性比較を行う場合、複数あるインスタンス変数の比較を行います。
+通常の場合、コードは次のようになります。
 
 [source,crystal]
 ----
@@ -199,7 +199,7 @@ include::./examples/record_01_macro.cr[tags=code;main]
 include::./projects/macro/src/parallel.cr[tags=code]
 ----
 
-これを実行すると、返り値、出力結果は次のようになります。
+これを実行すると、返り値、出力結果は次のようになります。
 
 [source,crystal,indent=0]
 ----
@@ -219,7 +219,7 @@ include::./projects/macro/src/parallel.cr[tags=main]
 
 === Macro の文法
 
-Macro の文法は https://crystal-lang.org/docs/syntax_and_semantics/macros.html[公式マニュアル] に記載されています。
+Macro の文法は https://crystal-lang.org/docs/syntax_and_semantics/macros.html[公式マニュアル] に記載されています。
 この章では公式マニュアルを基本とし、より詳しく解説していきます。
 
 ==== Macro のおさらい
@@ -241,20 +241,20 @@ include::./examples/syntax/basic_syntax.cr[tags=code;main]
 . 引数展開や条件分岐等の処理をし、 Crystal コードが生成される
 . 生成された Crystal コードを、Macro 呼び出し部分に展開する
 . すべての Macro を展開し終えたら、 Crystal コードのコンパイルをする
-. Crystal コードのコンパイルが終わったら実行する
+. Crystal コードのコンパイルが終わったら実行する
 
 この流れを頭の中に入れつつ、次のステップに進みましょう。
 
 ==== Macro と 抽象構文木
 
-Crystal のコードは、実際に実行する前にパーサによってパースされ、抽象構文木（  Abstract Syntax Tree ）を構築します。
+Crystal のコードは、実際に実行する前にパーサによってパースされ、抽象構文木（  Abstract Syntax Tree ）を構築します。
 抽象構文木を構成する木構造の各要素を AST node と言います。
 つまり、 Crystal のコードは各 AST node で構成されています。
 
 ここで Macro に話を戻します。
 Macro は Crystal のコードを組み立てるものでした。
 言い換えると「 Macro は AST node を操作して Crystal コードを組み立てるもの」ということになります。
-実際、 Macro が引数として受け取るのは AST node です。
+実際、 Macro が引数として受け取るのは AST node です。
 そのことを確かめてみましょう。
 
 ==== AST node
@@ -270,7 +270,7 @@ include::./examples/syntax/ast_node.cr[tags=code;main]
 これらの class は `Crystal::Macros::NumberLiteral` や `Crystal::Macros::ArrayLiteral` として定義されています。
 そして、全 AST node は `Crystal::Macros::ASTNode` を継承しています。 `Crystal::Macros::ASTNode` の幾つかのメソッドを紹介します。
 
-`#line_number` は、 AST node が書かれている行数を返します。
+`#line_number` は、 AST node が書かれている行数を返します。
 
 [source,crystal,indent=0]
 ----
@@ -294,14 +294,14 @@ include::./examples/syntax/ast_node_array_literal.cr[tags=code;main]
 ----
 
 通常の Crystal コードと似たような操作感で書くことができます。
-AST node を操作しているのか、 Crystal コードを操作しているのかをしっかりと意識してプログラミングしましょう。
+AST node を操作しているのか、 Crystal コードを操作しているのかをしっかりと意識してプログラミングしましょう。
 
 次からは、実際の文法を具体的に見ていきましょう。
 
 ==== スコープ
 
 Macro にもスコープがあります。
-次の例をみてください。
+次の例をみてください。
 
 *global に定義した場合*
 
@@ -382,7 +382,7 @@ include::./examples/syntax/for_hash.cr[tags=code;main]
 ----
 
 `for` も `if` と同様、 `macro` ディレクティブ以外の場所でも定義できます。
-
+
 [source,crystal,indent=0]
 ----
 include::./examples/syntax/for_outside.cr[tags=code;main]
@@ -449,11 +449,11 @@ include::./examples/syntax/nested_macros.cr[tags=code;main]
 "\{{greeting.id}} {{name.id}}"
 ----
 
-の部分では、外側の Macro で `{{name.id}}` の部分は展開されますが、 `\{{greeting.id}}` の部分は展開されません。
+の部分では、外側の Macro で `{{name.id}}` の部分は展開されますが、 `\{{greeting.id}}` の部分は展開されません。
 `\{{greeting.id}}` の部分は内側の Macro で展開されます。
 
 Nested macros は、 Macro の記述で重複が多い場合に有効です。
-しかし、可読性が損なわれやすいので注意が必要です。
+しかし、可読性が損なわれやすいので注意が必要です。
 
 ==== 生成コードの注意点
 
@@ -495,7 +495,7 @@ Macro には特別なインスタンス変数 `@type` が用意されていま�
 
 ===== TypeNode#instance_vars
 
-型に定義されているインスタンス変数を返します。
+型に定義されているインスタンス変数を返します。
 返り値は `Crystal::Macros::MetaVar` クラスの配列です。
 `MetaVar` クラスは、変数やインスタンス変数を表す型で、名前（ `MetaVar#name` ）と型（ `MetaVar#type` ）を持っています。
 
@@ -506,7 +506,7 @@ include::./examples/syntax/type_instance_vars.cr[tags=code;main]
 
 ===== TypeNode#methods
 
-型に定義されているメソッドの情報を返します。
+型に定義されているメソッドの情報を返します。
 返り値は `Crystal::Macros::Def` クラスの配列です。
 `Def` クラスは、 `def` ディレクティブを表す型で、メソッド定義に関するさまざまな情報を持っています。
 例えば、 `Def#args` は引数の情報、 `Def#return_type` はメソッドの返り値の型を表します。
@@ -517,7 +517,7 @@ include::./examples/syntax/type_methods.cr[tags=code;main]
 ----
 
 これらの他にもメソッドはたくさんあります。
-私の調べた限りでは、組み合わせればやりたいことはできるという、必要最低限なメソッドはそろっていました。
+私の調べた限りでは、組み合わせればやりたいことはできるという、必要最低限なメソッドはそろっていました。
 興味のある方はぜひ調べてみてください。
 
 ==== Hooks
@@ -534,10 +534,10 @@ Macro には、 hooks という特別な Macro が存在しています。
 |サブクラスが定義されている場合に実行される Macro
 
 | `macro included ... end`
-|モジュールが include されている場合に実行される Macro
+|モジュールが include されている場合に実行される Macro
 
 | `macro extended ... end`
-|モジュールが extend されている場合に実行される Macro
+|モジュールが extend されている場合に実行される Macro
 
 | `macro method_missing ... end`
 |メソッドが定義されていない場合に実行される Macro
@@ -560,7 +560,7 @@ include::./examples/syntax/hooks_inherited.cr[tags=code;main]
 include::./examples/syntax/hooks_method_missing.cr[]
 ----
 
-`method_missing` の引数は `Crystal::Macros::Call` です。
+`method_missing` の引数は `Crystal::Macros::Call` です。
 これはメソッドの呼び出しを表すクラスです。
 `#args` や `#receiver` などがあります。
 
@@ -586,7 +586,7 @@ include::./examples/syntax/fresh_variables_example2.cr[tags=code;main]
 
 `%変数名` とすることで、その Macro のコンテキスト内で唯一の変数として扱われます。
 仕組みは簡単です。
-上記のコードで `crystal tool expand` をしてみましょう。
+上記のコードで `crystal tool expand` をしてみましょう。
 
 [source,console,indent=0]
 ----
@@ -602,7 +602,7 @@ expansion 1:
 ----
 
 `__temp_20` のような変数に置き換わっています。
-このように、 Macro の実行フェーズで変数名を置き換えています。
+このように、 Macro の実行フェーズで変数名を置き換えています。
 
 Fresh variables は Hash 的な syntax もあります。
 `%変数名{キー}` と書きます。
@@ -613,13 +613,13 @@ Fresh variables は Hash 的な syntax もあります。
 include::./examples/syntax/fresh_variables_example3.cr[]
 ----
 
-これで、 Fresh variables を用いた for 文を書くことができます。
+これで、 Fresh variables を用いた for 文を書くことができます。
 
 === まとめ
 
 以上で、 Macro とはどういうものか、 Macro の文法はどうなっているのかなどの説明を終わります。
 Macro のおおまかなイメージは湧きましたでしょうか。
-自分はライブラリを書く際に Macro を使いますが、やはり重複排除の効果はすごいと思います。
+自分はライブラリを書く際に Macro を使いますが、やはり重複排除の効果はすごいと思います。
 また、 DSL の提供も比較的簡単にできるのではないでしょうか。
-Macro に慣れてくると、 Crystal 本来のコードを書くよりも Macro を書いている比率が多くなる印象が強いです。
+Macro に慣れてくると、 Crystal 本来のコードを書くよりも Macro を書いている比率が多くなる印象が強いです。
 今回のこの章を読み、「 Macro が読めるようになった」「 Macro が書けるようになった」という方が一人でも増えて頂けると幸いです。

--- a/04-macro/examples/syntax/ast_node.cr
+++ b/04-macro/examples/syntax/ast_node.cr
@@ -1,5 +1,5 @@
 # tag::code[]
-# 引数のclass_nameを表示させるmacro
+# 引数のclass_nameを表示させるmacro
 macro ast_node_class_name(ast_node)
   {{ ast_node.class_name }}
 end

--- a/04-macro/examples/syntax/type_instance_vars.cr
+++ b/04-macro/examples/syntax/type_instance_vars.cr
@@ -4,12 +4,12 @@ class MyClass
   end
 
   def instance_variables_name
-    # インスタンス変数の名前を配列で返す
+    # インスタンス変数の名前を配列で返す
     {{ @type.instance_vars.map(&.name.stringify) }}
   end
 
   def instance_variables_type
-    # インスタンス変数の型を配列で返す
+    # インスタンス変数の型を配列で返す
     {{ @type.instance_vars.map(&.type) }}
   end
 end

--- a/08-cli-development/content.adoc
+++ b/08-cli-development/content.adoc
@@ -13,14 +13,14 @@ Crystal で CLI ツールを書くメリットは次のようなものがあり�
 * コンパイル時に型チェックが入る
 
 CLI ツールは、欲しい時にサッと書けて継続的に使えるようにしたいですね。
-そういう意味では、 Crystal という選択肢は良いのではないでしょうか。
-今回初めて Crystal を触るという方も、まずは CLI ツールをサクッと作ってみることをおすすめします。
+そういう意味では、 Crystal という選択肢は良いのではないでしょうか。
+今回初めて Crystal を触るという方も、まずは CLI ツールをサクッと作ってみることをおすすめします。
 
 では、早速作っていきましょう。
 
 === 自作の echo コマンド「 myecho 」を作る
 
-`echo` コマンドを模倣した `myecho` コマンドを作っていきましょう。
+`echo` コマンドを模倣した `myecho` コマンドを作っていきましょう。
 まずは `crystal init app myecho` を実行してひな形を作ります。
 
 [source,console]
@@ -94,7 +94,7 @@ crystal spec spec/myecho_spec.cr:6 # MyEcho works
 include::./projects/myecho/spec/myecho_01_first_spec_failed.cr[]
 ----
 
-では、実際のテストから書いていきましょう。
+では、実際のテストから書いていきましょう。
 `myecho` の基本機能は「与えられた引数の文字列をそのまま出力する」です。
 
 [source,crystal]
@@ -104,7 +104,7 @@ include::./projects/myecho/spec/myecho_02_standart_output_spec.cr[tag=spec]
 ----
 <1> 出力する先の `IO` インスタンスを生成します。テスト時は `IO::Memory` に出力します。
 <2> `MyEcho::Cli` に `io` を渡し、インスタンスを生成します。
-<3> `MyEcho::Cli#run` に、コマンドライン引数の `ARGV` を模した `["foo", "bar"]` を渡して実行します。
+<3> `MyEcho::Cli#run` に、コマンドライン引数の `ARGV` を模した `["foo", "bar"]` を渡して実行します。
 <4> `io` に出力された文字列を検証します。
 
 まだ実装が終わっていないので、このテストは落ちます。
@@ -135,8 +135,8 @@ Finished in 66 microseconds
 次は build してバイナリを作りましょう。
 
 まずは build 対象のファイルを作ります。
-`src/myecho.cr` で `#run` を呼び出して直接 build してもよいですが、そうするとテスト時にも `#run` が実行されてしまいます。
-それを避けるために `cli.cr` ファイルを別途作成し、 `myecho.cr` を require しましょう。
+`src/myecho.cr` で `#run` を呼び出して直接 build してもよいですが、そうするとテスト時にも `#run` が実行されてしまいます。
+それを避けるために `cli.cr` ファイルを別途作成し、 `myecho.cr` を require しましょう。
 
 [source,crystal]
 .src/cli.cr
@@ -153,7 +153,7 @@ $ mkdir bin
 $ crystal build -o ./bin/myecho ./src/cli.cr
 ----
 
-`./bin/` ディレクトリを作成し、その中に `myecho` という名前でバイナリを出力しています。
+`./bin/` ディレクトリを作成し、その中に `myecho` という名前でバイナリを出力しています。
 `myecho` を実行してみましょう。
 
 [source,console]
@@ -194,7 +194,7 @@ include::./projects/myecho/spec/myecho_03_display_version_v_spec.cr[tag=version]
 <3> version を表示するコマンドライン引数 `["-v"]` を渡して実行します。
 <4> `MyEcho::VERSION` が表示されていることを検証します。
 
-テストを回しましょう。
+テストを回しましょう。
 
 [source,console]
 ----
@@ -232,7 +232,7 @@ crystal spec spec/myecho_spec.cr:14 # MyEcho MyEcho::Cli run writes the version 
 include::./projects/myecho/src/myecho_03_display_version_v.cr[]
 ----
 <1> 標準ライブラリの `OptionParser` を require します。
-<2> `OptionParser#parse` に `args` を渡し、ブロック内でオプションを定義していきます。
+<2> `OptionParser#parse` に `args` を渡し、ブロック内でオプションを定義していきます。
 <3> `OptionParser#on` の引数に `-v` とその説明文を、ブロックには実行したい処理を書きます。
 <4> オプション以外の引数は、配列になって `OptionParser#unknown_args` のブロック引数となります。
 
@@ -249,7 +249,7 @@ Finished in 102 microseconds
 
 通りました。
 バイナリも作りましょう。
-そして、実際にバージョンを表示してみましょう。
+そして、実際にバージョンを表示してみましょう。
 
 [source,console]
 ----
@@ -320,7 +320,7 @@ Finished in 189 microseconds
 6 examples, 0 failures, 0 errors, 0 pending
 ----
 
-実際にバージョンを表示してみましょう。
+実際にバージョンを表示してみましょう。
 
 [source,console]
 ----
@@ -339,7 +339,7 @@ $ ./bin/myecho --version
 === ヘルプ表示のオプション `-h` `--help` を実装する
 
 次にヘルプを表示してみます。
-オプションの追加はバージョン表示の時と同じです。
+オプションの追加はバージョン表示の時と同じです。
 まずはテストから書きましょう。
 
 [source,crystal,indent=0]
@@ -350,7 +350,7 @@ include::./projects/myecho/spec/myecho_05_display_help_specified_string_spec_fai
 
 `-h` を指定した場合、何が表示されるかはまだわかりません。
 とりあえずこのまま進みましょう。
-現状だと、 `Invalid option: -h` でテストが落ちることは目に見えています。
+現状だと、 `Invalid option: -h` でテストが落ちることは目に見えています。
 まずは適当に文字列を返しましょう。
 
 [source,crystal,indent=2]
@@ -467,7 +467,7 @@ $ ./bin/myecho --help
     -v, --version                    show version
 ----
 
-ヘルプが表示されました。
+ヘルプが表示されました。
 しかし、もう少し体裁の整ったヘルプがよいですね。
 例えば、コマンドの説明や Usage などがあると良さそうです。
 テストを書きましょう。
@@ -480,7 +480,7 @@ include::./projects/myecho/spec/myecho_07_display_help_banner_spec.cr[tag=help]
 
 良い感じのヘルプにしてみました。
 テストが通るように実装しましょう。
-`OptionParser` には、 `#banner=` というメソッドがあり、ヘルプメッセージに加える文字列を定義できます。
+`OptionParser` には、 `#banner=` というメソッドがあり、ヘルプメッセージに加える文字列を定義できます。
 
 [source,crystal,indent=2]
 .src/myecho.cr の一部
@@ -549,7 +549,7 @@ include::./projects/myecho/src/myecho_08_prefix.cr[tag=display_prefix]
 ----
 
 `OptionParser#on` は、 `long_flag` の名前だけでも指定可能です。
-`--prefix PREFIX` のように、オプション引数（ `PREFIX` ）を書くと、オプション引数が必須になります。
+`--prefix PREFIX` のように、オプション引数（ `PREFIX` ）を書くと、オプション引数が必須になります。
 また、今回の `--prefix` 定義のままで、コマンドラインから `--prefix=PREFIX` のように `=` を用いた指定も可能です。
 いい感じに取り扱ってくれます。
 
@@ -590,7 +590,7 @@ include::./projects/myecho/src/myecho.cr[]
 include::./projects/myecho/spec/myecho_spec.cr[]
 ----
 
-次は、もう少しかゆいところに手が届く、サードパーティ製の CLI ビルダーライブラリをいくつかご紹介します。
+次は、もう少しかゆいところに手が届く、サードパーティ製の CLI ビルダーライブラリをいくつかご紹介します。
 
 === サードパーティ製のライブラリを使う
 
@@ -600,11 +600,11 @@ CLI ツールを作成するにあたって、サードパーティ製の CLI �
 Crystal でも CLI ビルダーツールが作成されています。
 今回は主観で選択したいくつかをご紹介します。
 
-題材としては、ここまで作ってきた `myecho` を用います。
+題材としては、ここまで作ってきた `myecho` を用います。
 
 ==== mrrooijen/commander
 
-早い時期から作成されていたライブラリです。
+早い時期から作成されていたライブラリです。
 百聞は一見に如かず、早速 `myecho` を実装しましょう。
 
 [source,crystal,indent=0]
@@ -616,7 +616,7 @@ include::./projects/myecho_commander/src/myecho_commander.cr[]
 サードパーティ製のライブラリは、基本的に次の構成になっています。
 
 * コマンドの説明（ `Description` や `Usage` など）
-* `Options` や `Flags` の定義
+* `Options` や `Flags` の定義
 * 実際に実行される箇所
 ** `run` メソッドや `run` ブロックなど
 ** ここで `Options` や `Flags` の入力値を受け取れる
@@ -629,7 +629,7 @@ include::./projects/myecho_commander/src/myecho_commander.cr[]
 また、サブコマンドも実装可能です。
 詳しくは公式マニュアルを御覧ください。
 
-コードを実際に実行すると次のようになります。
+コードを実際に実行すると次のようになります。
 
 [source,console]
 ----
@@ -673,7 +673,7 @@ include::./projects/myecho_admiral/src/myecho_admiral.cr[]
 構造もわかりやすく、読みやすいと思います。
 もちろん、サブコマンドも対応しています。
 
-実際に実行すると次のようになります。
+実際に実行すると次のようになります。
 
 [source,console]
 ----
@@ -709,13 +709,13 @@ pre_foo pre_bar pre_baz
 include::./projects/myecho_clim/src/myecho_clim.cr[]
 ----
 
-`desc` や `option` などの定義が１行で書けます。
+`desc` や `option` などの定義が１行で書けます。
 `version` マクロも用意しました。
 コマンドの実行箇所は、 `run` ブロックになります。
 サブコマンドも対応しており、直感的に記述することができます。
 詳しくはマニュアルを御覧ください。
 
-実際に実行すると次のようになります。
+実際に実行すると次のようになります。
 
 [source,console]
 ----


### PR DESCRIPTION
なぜか分からないけれど大量にあったので削除しました。

どうしてこんなにあるんだろう‥‥。