### PR TITLE
コードブロックの上のソースコード名の表示を統一

### DIFF
--- a/01-introduction/content.adoc
+++ b/01-introduction/content.adoc
@@ -72,6 +72,7 @@ NOTE: https://www.infoq.com/presentations/Null-References-The-Billion-Dollar-Mis
 次のプログラムを見てください。
 
 [source,crystal]
+.hello_world.cr
 ----
 if rand(2) > 0
   my_string = "hello world"

--- a/02-getting-started/content.adoc
+++ b/02-getting-started/content.adoc
@@ -195,6 +195,7 @@ WSL 上での Crystal のインストール方法は、それぞれの Linux デ
 Crystal のインストールができたら、以下のコマンドを実行してみましょう。これで、Crystal がインストールされて利用できる状態かどうかが確認できます。
 
 [source,console]
+.hello.cr
 ----
 $ crystal -v
 ----

--- a/04-macro/content.adoc
+++ b/04-macro/content.adoc
@@ -305,30 +305,26 @@ AST node を操作しているのか、 Crystal コードを操作している�
 Macro にもスコープがあります。
 次の例をみてください。
 
-*global に定義した場合*
-
 [source,crystal,indent=0]
+.global に定義した場合
 ----
 include::./examples/syntax/macro_scope_global.cr[tags=code;main]
 ----
 
-*private を付けて global に定義した場合*
-
 [source,crystal,indent=0]
+.private を付けて global に定義した場合
 ----
 include::./examples/syntax/macro_scope_global_private.cr[tags=code;main]
 ----
 
-*class 内に定義した場合*
-
 [source,crystal,indent=0]
+.class 内に定義した場合
 ----
 include::./examples/syntax/macro_scope_class.cr[tags=code;main]
 ----
 
-*module 内に定義した場合*
-
 [source,crystal,indent=0]
+.module 内に定義した場合
 ----
 include::./examples/syntax/macro_scope_module.cr[tags=code;main]
 ----

--- a/05-shards/content.adoc
+++ b/05-shards/content.adoc
@@ -26,8 +26,8 @@ RubyGems と Shards の大きな違いは、パッケージのインストール
 
 プロジェクト名は、shard として公開するのであればいくつかルール（後述）もありますが、そうでない場合にはそこまで深く考える必要はありません。今回はシンプル（simple）な HTML を返すアプリなので `simple_html` というプロジェクト名にすることにします。
 
-.● sinple_html コマンド利用イメージ
-
+[source,console]
+.`simple_html` コマンド利用イメージ
 ----
 $ simple_html "Page Title" "Page body."
 <html><head><title>Page Title</title></head><body><h1>Page Title</h1><p>Page body.</p></body></html>
@@ -39,13 +39,13 @@ $ simple_html "Page Title" "Page body."
 
 `crystal init` コマンドを実行する際には、プロジェクトの種類（`app` もしくは `lib`）とプロジェクト名を指定します。例えば、`simple_html` をアプリケーションとして実装する場合のひな形生成コマンドは `crystal init app simple_html` です。このコマンドを実行するとカレントディレクトリの直下にプロジェクト名と同じ名前の simple_html ディレクトリができ、その中に各種ひな型が自動生成されます。
 
-.● simple_html アプリケーション用プロジェクトのひな形生成コマンド
-
+[source,console]
+.`simple_html` アプリケーション用プロジェクトのひな形生成コマンド
 ----
 $ crystal init app simple_html
 ----
 
-.● プロジェクトひな形として生成されるファイル/ディレクトリ
+.プロジェクトひな形として生成されるファイル/ディレクトリ
 
 `.git/`（ディレクトリ）:: このプロジェクト用の初期化済み git リポジトリ。
 


### PR DESCRIPTION
ソースコード名や、ソースコードのキャプションは、

```adoc
[source]
.ソースコード名
----
...
----
```

がいいと思うのでこっちに統一しています。