### PR TITLE
Ignore `docs/.jekyll-cache/` in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /Makefile.local
 /vendor/redpen-distribution-*
 /.sass-cache/
+docs/.jekyll-cache/


### PR DESCRIPTION
`bundle exec rake -j` を以下の環境で実行したとき、`Untracked files` に このディレクトリが現れたのでPRを送っておきますね 🙏 

```sh
docker container run --volume="$(pwd)/:/usr/src" --workdir='/usr/src/' -it 'ruby:2.6.5' '/bin/bash'
```

```
root@14acc671eabd:/usr/src# uname -a
Linux 14acc671eabd 4.19.121-linuxkit #1 SMP Tue Dec 1 17:50:32 UTC 2020 x86_64 GNU/Linux
root@14acc671eabd:/usr/src# ruby -v
'ruby 2.6.5p114 (2019-10-01 revision 67812) [x86_64-linux]
```