### PR TITLE
Ignore all `/vendor/` files in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 /build/
 /.tmp/
-/vendor/bundle
+/vendor/
 /.bundle/
 /Makefile.local
-/vendor/redpen-distribution-*
 /.sass-cache/
 docs/.jekyll-cache/


### PR DESCRIPTION
https://github.com/crystal-jp/introducing-crystal/tree/fad5fa88a0fc134eed61155ccdb224b7b9dae79b#ci-%E7%94%A8%E3%81%AE%E3%82%B3%E3%83%B3%E3%83%86%E3%83%8A%E3%81%AE%E3%83%93%E3%83%AB%E3%83%89%E6%96%B9%E6%B3%95

に

```
CI 用のコンテナのビルド方法
RedPen 1.10.1の .tar.gz を落としてきて vendor/ 以下に展開したあと、次のコマンドを実行します。

$ docker build -t makenowjust/techbookfest-build -f .circleci/images/build/Dockerfile .
```

と記載もあり、 `/vendor/` 配下は全て ignore してしまった方が便利かな、と思ったのですがどうでしょう。？ 😄 