### PR TITLE
Correct testing command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ server.listen(8080)
 
 ビルドとテストは、
 
-  - `Makefile` が無い場合は、 `shards build` と `crystal spec` を実行します。
+  - `Makefile` が無い場合は、 `shards` と `crystal spec` を実行します。
   - `Makefile` がある場合は、 `make` と `make test` を実行します。
 
 という風にして実行します。


### PR DESCRIPTION
https://github.com/crystal-jp/introducing-crystal/blob/7066d90abef3c469ef8426ae21e4f57adaa93148/script/project-test.rb#L26-L36

ここが該当の箇所かな？と踏んだのですが、そうすると実際には `shards build` ではなく `shards` (==`shards install`) を行っているのかなと思い修正してみました。